### PR TITLE
Uniqueness validation case_sensitive: false so that slugs can't be duped regardless of case

### DIFF
--- a/lib/slug/slug.rb
+++ b/lib/slug/slug.rb
@@ -26,7 +26,7 @@ module Slug
       self.slug_column = opts.fetch(:column, :slug)
       self.generic_default = opts.fetch(:generic_default, false)
 
-      uniqueness_opts = {}
+      uniqueness_opts = { case_sensitive: false }
       uniqueness_opts.merge!(:if => opts[:validate_uniqueness_if]) if opts[:validate_uniqueness_if].present?
       validates_uniqueness_of self.slug_column, uniqueness_opts
 


### PR DESCRIPTION
Addresses a deprecation warning for Rails 6.1:
```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :slug attribute in the model, pass `case_sensitive: true` option explicitly to the uniqueness validator.
```